### PR TITLE
Adding notebooks for events data

### DIFF
--- a/data-updates/notebooks/app_ees_accordions.r
+++ b/data-updates/notebooks/app_ees_accordions.r
@@ -1,0 +1,217 @@
+# Databricks notebook source
+# DBTITLE 1,Load dependencies
+source("utils.R")
+
+packages <- c("sparklyr", "DBI", "dplyr", "testthat", "arrow", "stringr")
+
+install_if_needed(packages)
+lapply(packages, library, character.only = TRUE)
+
+ga4_event_table_name <- "catalog_40_copper_statistics_services.analytics_raw.ees_ga4_events"
+ua_event_table_name <- "catalog_40_copper_statistics_services.analytics_raw.ees_ua_events"
+scrape_table_name <- "catalog_40_copper_statistics_services.analytics_raw.ees_pub_scrape"
+write_table_name <- "catalog_40_copper_statistics_services.analytics_app.ees_accordions"
+
+sc <- spark_connect(method = "databricks")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC
+# MAGIC For accordion opens in GA4 we need:
+# MAGIC
+# MAGIC **eventName**
+# MAGIC - Content Accordion Opened
+# MAGIC - Annexes Accordion Opened
+# MAGIC - Accordion Opened
+# MAGIC - Data Accordion Opened
+# MAGIC - Publications Accordion Opened
+# MAGIC
+# MAGIC eventLabel gives the relevant accordion name
+# MAGIC
+# MAGIC eventCategory gives the title of the page the event occured on
+# MAGIC
+# MAGIC For accordion opens in UA we need: 
+# MAGIC
+# MAGIC **eventAction**
+# MAGIC - Content Accordion Opened
+# MAGIC - Accordion Opened
+# MAGIC - Annexes Accordion Opened
+# MAGIC - Data Accordion Opened
+# MAGIC - Publications Accordion Opened
+# MAGIC - Publications+Accordion+Opened << this one doesn't exist in GA4
+# MAGIC
+# MAGIC eventLabel gives the relevant accordion name
+# MAGIC
+# MAGIC eventCategory gives the title of the page the event occured on
+
+# COMMAND ----------
+
+# DBTITLE 1,Join the tables together and filter to just accordion relevant events
+
+## I've done this with a group by because otherwise the tests would fail because of duplicates. This could mean I'm just double counting on the day overlap between the two tables - but would need to investigate more to find out.
+
+full_data <- sparklyr::sdf_sql(
+  sc, paste("
+    SELECT 
+      date, 
+      pagePath,
+      eventName,
+      eventLabel,
+      eventCategory,
+      SUM(eventCount) as eventCount
+    FROM (
+      SELECT 
+      date, 
+      pagePath,
+      eventAction as eventName,
+      eventLabel,
+      eventCategory, 
+      totalEvents as eventCount     
+      FROM ", ua_event_table_name, "
+      UNION ALL
+      SELECT 
+      date, 
+      pagePath,
+      eventName,
+      eventLabel,
+      eventCategory,
+      eventCount 
+      FROM ", ga4_event_table_name, "
+    ) AS p
+    GROUP BY date, pagePath, eventName, eventLabel, eventCategory
+    ORDER BY date DESC
+  ")
+) %>% collect()
+
+accordion_events <- full_data %>% filter(eventName %in% c('Content Accordion Opened', 'Accordion Opened', 'Annexes Accordion Opened', 'Data Accordion Opened', 'Publications Accordion Opened', 'Publications+Accordion+Opened'))
+
+# COMMAND ----------
+
+# DBTITLE 0,Join together and check table integrity
+test_that("No duplicate rows", {
+  expect_true(nrow(accordion_events) == nrow(dplyr::distinct(accordion_events)))
+})
+
+test_that("Data has no missing values", {
+  expect_false(any(is.na(accordion_events)))
+})
+
+dates <- create_dates(max(accordion_events$date))
+
+test_that("There are no missing dates since we started", {
+  expect_equal(
+    setdiff(accordion_events$date, seq(as.Date(dates$all_time_date), max(dates$latest_date), by = "day")) |>
+      length(),
+    0
+  )
+})
+
+
+# COMMAND ----------
+
+# DBTITLE 1,Adding a page type grouping
+accordion_events <- accordion_events %>%
+  mutate(page_type = case_when(
+    ## Main recording/groupings for the pages we'll be most interested in
+    str_detect(eventCategory, "Release Page") ~ "Release page",
+    str_detect(eventCategory, "Methodology") ~ "Methodology",
+    str_detect(eventCategory, "Glossary") ~ "Glossary",
+    ## Some manual faffery to address the publications that have too long a title
+    str_detect(eventCategory, "Attendance in Education and Early Years Settings During the Coronavirus \\(COVID-19\\) Pandemic Release ") ~ "Release page",    
+    str_detect(eventCategory, "Attendance in Education and Early Years Settings During the Coronavirus \\(COVID-19\\) Pandemic Methodol") ~ "Methodology",
+    str_detect(eventCategory, "Outcomes for Children in Need, Including Children Looked After by Local Authorities in England Metho") ~ "Methodology",
+    str_detect(eventCategory, "Outcomes for Children in Need, Including Children Looked After by Local Authorities in England Relea") ~ "Release page", 
+    ## Service pages that have / did have accordions, might be helpful to look at but not main focus
+    str_detect(eventCategory, "Methodologies") ~ "Methodology navigation",
+    str_detect(eventCategory, "Find Statistics and Data") ~ "Find stats navigation",
+    str_detect(eventCategory, "Find\\+Statistics\\+and\\+Data") ~ "Find stats navigation",
+    str_detect(eventCategory, "Download Index Page") ~ "Old data catalogue",
+    TRUE ~ 'NA'
+  ))
+
+# COMMAND ----------
+
+# DBTITLE 1,Tests
+test_that("There are no events without a page type classification", {
+    expect_true(nrow(accordion_events %>% filter(page_type =='NA')) == 0)
+    })
+
+# COMMAND ----------
+
+# DBTITLE 1,Bringing in scraped publications list
+scraped_publications <- sparklyr::sdf_sql(sc, paste("SELECT * FROM", scrape_table_name)) |> collect()
+
+slugs <- unique(scraped_publications$slug)
+
+# COMMAND ----------
+
+# DBTITLE 1,Joining publication info
+# Joining publication info onto the publication specific events
+# TO DO: join to methodology pages too
+accordion_events <- accordion_events |>
+  mutate(slug = str_remove(pagePath, "^/find-statistics/")) |>
+  mutate(slug = str_remove(slug, "/.*")) |>
+  mutate(slug = str_remove(slug, "\\.$")) |>
+  left_join(scraped_publications, by = c("slug" = "slug")) |>
+  rename("publication" = title)
+ ## select(date, pagePath, publication, pageviews, sessions)
+
+dates <- create_dates(max(accordion_events$date))
+
+test_that("There are no missing dates since we started", {
+  expect_equal(
+    setdiff(accordion_events$date, seq(as.Date(dates$all_time_date), max(dates$latest_date), by = "day")) |>
+      length(),
+    0
+  )
+})
+
+# COMMAND ----------
+
+# selecting jus tthe columns we're interested in storing
+# TO DO: decide if we only want subsets of page_types in here (e.g make it just about publications or remove defunct pages like data catalogue)
+
+accordion_events <- accordion_events %>%
+select(date, pagePath, page_type, publication, eventLabel, eventCount)
+
+# COMMAND ----------
+
+# DBTITLE 1,Write out app data
+updated_spark_df <- copy_to(sc, accordion_events, overwrite = TRUE)
+
+# Write to temp table while we confirm we're good to overwrite data
+spark_write_table(updated_spark_df, paste0(write_table_name, "_temp"), mode = "overwrite")
+
+temp_table_data <- sparklyr::sdf_sql(sc, paste0("SELECT * FROM ", write_table_name, "_temp")) %>% collect()
+previous_data <- tryCatch(
+  {
+    sparklyr::sdf_sql(sc, paste0("SELECT * FROM ", write_table_name)) %>% collect()
+  },
+  error = function(e) {
+    NULL
+  }
+)
+
+test_that("Temp table data matches updated data", {
+  expect_equal(temp_table_data, accordion_events)
+})
+
+# Replace the old table with the new one
+dbExecute(sc, paste0("DROP TABLE IF EXISTS ", write_table_name))
+dbExecute(sc, paste0("ALTER TABLE ", write_table_name, "_temp RENAME TO ", write_table_name))
+
+print_changes_summary(temp_table_data, previous_data)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC We're left with the following table 
+# MAGIC
+# MAGIC - **date**: The date the event occured on (earliest date = 21/04/2021)
+# MAGIC - **pagePath**: The pagePath the event occured on
+# MAGIC - **page_type**: Type of service page (Release page, methoodlogy, glossary etc)
+# MAGIC - **publication**: The publication title (relevant for 'Release page' page_types only atm, need to update code to add to methodology pages too)
+# MAGIC - **eventLabel**: The accordion title
+# MAGIC - **eventCount**: The number of accordion click events on given day
+# MAGIC

--- a/data-updates/notebooks/app_ees_accordions.r
+++ b/data-updates/notebooks/app_ees_accordions.r
@@ -148,14 +148,15 @@ slugs <- unique(scraped_publications$slug)
 
 # DBTITLE 1,Joining publication info
 # Joining publication info onto the publication specific events
-# TO DO: join to methodology pages too
 accordion_events <- accordion_events |>
-  mutate(slug = str_remove(pagePath, "^/find-statistics/")) |>
+  mutate(slug = str_remove(pagePath, "^/(methodology|find-statistics|data-tables|data-catalogue)/")) |>
+  mutate(slug = str_remove(slug, "-methodology")) |>
   mutate(slug = str_remove(slug, "/.*")) |>
-  mutate(slug = str_remove(slug, "\\.$")) |>
+  mutate(slug = str_trim(slug, side = "both")) |>
+  mutate(slug = str_remove_all(slug, "[^a-zA-Z0-9-]")) |>
+  mutate(slug = str_to_lower(slug)) |>
   left_join(scraped_publications, by = c("slug" = "slug")) |>
   rename("publication" = title)
- ## select(date, pagePath, publication, pageviews, sessions)
 
 dates <- create_dates(max(accordion_events$date))
 
@@ -169,7 +170,7 @@ test_that("There are no missing dates since we started", {
 
 # COMMAND ----------
 
-# selecting jus tthe columns we're interested in storing
+# selecting just the columns we're interested in storing
 # TO DO: decide if we only want subsets of page_types in here (e.g make it just about publications or remove defunct pages like data catalogue)
 
 accordion_events <- accordion_events %>%
@@ -211,7 +212,7 @@ print_changes_summary(temp_table_data, previous_data)
 # MAGIC - **date**: The date the event occured on (earliest date = 21/04/2021)
 # MAGIC - **pagePath**: The pagePath the event occured on
 # MAGIC - **page_type**: Type of service page (Release page, methoodlogy, glossary etc)
-# MAGIC - **publication**: The publication title (relevant for 'Release page' page_types only atm, need to update code to add to methodology pages too)
+# MAGIC - **publication**: The publication title (relevant for pages that have an associated publication only)
 # MAGIC - **eventLabel**: The accordion title
 # MAGIC - **eventCount**: The number of accordion click events on given day
 # MAGIC

--- a/data-updates/notebooks/app_ees_downloads.r
+++ b/data-updates/notebooks/app_ees_downloads.r
@@ -296,11 +296,3 @@ print_changes_summary(temp_table_data, previous_data)
 # MAGIC - **eventLabel**: The info we have for what file was downloaded (this often includes the relevant publication too though is truncated unhelpfully)
 # MAGIC - **eventCount**: The number of downloads of that type on given day
 # MAGIC
-
-# COMMAND ----------
-
-# MAGIC %sql
-# MAGIC select page_type, download_type, sum(eventCount)
-# MAGIC from catalog_40_copper_statistics_services.analytics_app.ees_downloads
-# MAGIC group by page_type, download_type
-# MAGIC order by page_type, download_type

--- a/data-updates/notebooks/app_ees_downloads.r
+++ b/data-updates/notebooks/app_ees_downloads.r
@@ -241,13 +241,6 @@ test_that("There are no missing dates since we started", {
 
 # COMMAND ----------
 
-# MAGIC %sql
-# MAGIC select * from
-# MAGIC catalog_40_copper_statistics_services.analytics_app.ees_downloads
-# MAGIC where publication is null
-
-# COMMAND ----------
-
 # selecting just the columns we're interested in storing
 # TO DO: decide if we only want subsets of page_types in here (e.g make it just about publications or remove defunct pages like data catalogue)
 

--- a/data-updates/notebooks/app_ees_downloads.r
+++ b/data-updates/notebooks/app_ees_downloads.r
@@ -1,0 +1,293 @@
+# Databricks notebook source
+# DBTITLE 1,Load dependencies
+source("utils.R")
+
+packages <- c("sparklyr", "DBI", "dplyr", "testthat", "arrow", "stringr")
+
+install_if_needed(packages)
+lapply(packages, library, character.only = TRUE)
+
+ga4_event_table_name <- "catalog_40_copper_statistics_services.analytics_raw.ees_ga4_events"
+ua_event_table_name <- "catalog_40_copper_statistics_services.analytics_raw.ees_ua_events"
+scrape_table_name <- "catalog_40_copper_statistics_services.analytics_raw.ees_pub_scrape"
+write_table_name <- "catalog_40_copper_statistics_services.analytics_app.ees_downloads"
+
+sc <- spark_connect(method = "databricks")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC
+# MAGIC For search events in GA4 we need:
+# MAGIC
+# MAGIC **eventName**
+# MAGIC
+# MAGIC - CSV Download Button Clicked (table tool, permalinks)
+# MAGIC - Data Set File Download (data catalogue)
+# MAGIC - Download All Data Button Clicked (release pages)
+# MAGIC - ODS Download Button Clicked (table tool, permalinks)
+# MAGIC - Data Set File Download - All (data catalogue)
+# MAGIC - Release Page File Downloaded (release ancillary)
+# MAGIC
+# MAGIC **eventLabel** gives the dataset title
+# MAGIC
+# MAGIC **eventCategory** gives either the page title for where the download event occured on
+# MAGIC
+# MAGIC NOTE:
+# MAGIC We also have tracking for the following eventName's but are conciously not including them here as they only appear in one row each and seem to be in error
+# MAGIC
+# MAGIC - Release Page All Files downloads.title}, (release pages)
+# MAGIC - file_download
+# MAGIC
+# MAGIC NOTE: 
+# MAGIC We don't seem to be tracking any searches on the table tool
+# MAGIC
+# MAGIC For search events in UA we need: 
+# MAGIC
+# MAGIC **eventAction**
+# MAGIC - Release Page File Downloaded (release pages)
+# MAGIC - CSV Download Button Clicked (table tool, permalinks)
+# MAGIC - Excel Download Button Clicked (table tool, permalinks)
+# MAGIC - ODS Download Button Clicked (table tool, permalinks)
+# MAGIC - Data Catalogue Page Selected Files Download (data catalogue)
+# MAGIC - Release Page All Files Downloaded (release pages)
+# MAGIC - Download All Data Button Clicked (release pages)
+# MAGIC - Release Page All Files downloads.title}, Release: Week 8 2023, File: All Files (and similar across all pubs) (release pages)
+# MAGIC
+# MAGIC **eventLabel** gives the search term used
+# MAGIC
+# MAGIC **eventCategory** gives either the page title or slug of the page the search event occured on
+# MAGIC
+# MAGIC NOTE:
+# MAGIC We also have tracking for the following eventName's but are conciously not including them here
+# MAGIC - Download Latest Data Page All Files Downloaded (old data catalogue)
+# MAGIC - Download Latest Data Page File Downloaded (old data catalogue)
+
+# COMMAND ----------
+
+# DBTITLE 1,Join the tables together and filter to just accordion relevant events
+
+## I've done this with a group by because otherwise the tests would fail because of duplicates. This could mean I'm just double counting on the day overlap between the two tables - but would need to investigate more to find out.
+
+full_data <- sparklyr::sdf_sql(
+  sc, paste("
+    SELECT 
+      date, 
+      pagePath,
+      eventName,
+      eventLabel,
+      eventCategory,
+      SUM(eventCount) as eventCount
+    FROM (
+      SELECT 
+      date, 
+      pagePath,
+      eventAction as eventName,
+      eventLabel,
+      eventCategory, 
+      totalEvents as eventCount     
+      FROM ", ua_event_table_name, "
+      UNION ALL
+      SELECT 
+      date, 
+      pagePath,
+      eventName,
+      eventLabel,
+      eventCategory,
+      eventCount 
+      FROM ", ga4_event_table_name, "
+    ) AS p
+    GROUP BY date, pagePath, eventName, eventLabel, eventCategory
+    ORDER BY date DESC
+  ")
+) %>% collect()
+
+downloads <- full_data %>% 
+  filter(
+    eventName %in% c('CSV Download Button Clicked', 'Data Set File Download', 'Download All Data Button Clicked', 'ODS Download Button Clicked', 'Data Set File Download - All', 'Release Page File Downloaded', 'Excel Download Button Clicked', 'Data Catalogue Page Selected Files Download', 'Release Page All Files Downloaded') | 
+    str_starts(eventName, "Release Page All Files downloads.title, Release:")
+  )
+
+
+# COMMAND ----------
+
+# DBTITLE 0,Join together and check table integrity
+test_that("No duplicate rows", {
+  expect_true(nrow(downloads) == nrow(dplyr::distinct(downloads)))
+})
+
+test_that("Data has no missing values", {
+  expect_false(any(is.na(downloads)))
+})
+
+dates <- create_dates(max(downloads$date))
+
+test_that("There are no missing dates since we started", {
+  expect_equal(
+    setdiff(downloads$date, seq(as.Date(dates$all_time_date), max(dates$latest_date), by = "day")) |>
+      length(),
+    0
+  )
+})
+
+
+# COMMAND ----------
+
+# DBTITLE 1,Adding a page_type column to help distinguish between different types of download
+downloads <- downloads %>%
+  mutate(page_type = case_when(
+
+    str_detect(eventCategory, "Table Tool") ~ "Table tool",
+    
+    str_detect(eventCategory, "Data Catalogue") ~ "Data catalogue",
+    str_detect(eventCategory, "Data Catalogue - Data Set Page") ~ "Data catalogue",
+    str_detect(eventName, "Data Catalogue Page Selected Files Download") ~ "Data catalogue",
+    
+    str_detect(eventCategory, "Permalink Page") ~ "Permalinks",
+
+    str_detect(eventName, "Release Page File Downloaded") ~ "Release page",
+    str_detect(eventName, "Release Page All Files Downloaded") ~ "Release page",
+    str_detect(eventCategory, "- Useful Information") ~ "Release page",
+    str_detect(eventCategory, "Attendance in Education and Early Years Settings During the Coronavirus \\(COVID-19\\) Pandemic Release ") ~ "Release page",
+    str_detect(eventCategory, "Outcomes for Children in Need, Including Children Looked After by Local Authorities in England Relea") ~ "Release page",
+    str_detect(eventCategory, "Participation in Education, Training and NEET Age 16 to 17 by Local Authority Release Page - Useful ") ~ "Release page",
+    str_detect(eventCategory, "Higher Education Entrants and Qualifiers by Their Level 2 and 3 Attainment Release Page - Useful Inf") ~ "Release page",
+    str_detect(eventCategory, "September Guarantee: Offers of Education and Training for Young People Age 16 and 17 Release Page - ") ~ "Release page",
+    str_detect(eventCategory, "UK Revenue From Education Related Exports and Transnational Education Activity Release Page - Useful") ~ "Release page",
+    str_detect(eventCategory, "Foundation Year Participation, Provision and Outcomes at HE Providers Release Page - Useful Informat") ~ "Release page",
+    str_detect(eventCategory, "FE Learners Going Into Employment and Learning Destinations by Local Authority District Release Page") ~ "Release page",
+    str_detect(eventCategory, "Expansion to Early Childcare Entitlements: Eligibility Codes Issued and Validated Release Page - Use") ~ "Release page",
+    str_detect(eventCategory, "Looked After Children Aged 16 to 17 in Independent or Semi-Independent Placements Release Page - Use") ~ "Release page",
+    str_detect(eventCategory, "Education, Children’s Social Care and Offending: Local Authority Level Dashboard Release Page - Usef") ~ "Release page",
+    str_detect(eventCategory, "Children's Social Work Workforce: Attrition, Caseload, and Agency Workforce Release Page - Useful In") ~ "Release page",
+
+    TRUE ~ 'NA'
+  ))
+
+
+# COMMAND ----------
+
+test_that("There are no events without a page type classification", {
+    expect_true(nrow(downloads %>% filter(page_type =='NA')) == 0)
+    })
+
+# COMMAND ----------
+
+# DBTITLE 1,Adding a download_type column to help distinguish between different types of download
+downloads <- downloads %>%
+  mutate(download_type = case_when(
+
+    str_detect(eventName, "ODS Download Button Clicked") ~ "ODS",
+    
+    str_detect(eventName, "CSV Download Button Clicked") ~ "CSV",
+
+    str_detect(eventName, "Excel Download Button Clicked") ~ "Excel",
+    
+    str_detect(eventName, "Download All Data Button Clicked") ~ "All files",
+    str_detect(eventName, "Release Page All Files Downloaded") ~ "All files",
+    str_starts(eventName, "Release Page All Files downloads.title") ~ "All files",
+    str_detect(eventName, "Data Set File Download - All") ~ "All files",
+
+    str_detect(eventName, "Data Set File Download") ~ "Data catalogue",
+    str_detect(eventName, "Data Catalogue Page Selected Files Download") ~ "Data catalogue",
+
+    str_detect(eventName, "Release Page File Downloaded") ~ "Ancillary",
+
+    TRUE ~ 'NA'
+  ))
+
+
+# COMMAND ----------
+
+# DBTITLE 1,Tests
+test_that("There are no events without a page type classification", {
+    expect_true(nrow(downloads %>% filter(download_type =='NA')) == 0)
+    })
+
+# COMMAND ----------
+
+# DBTITLE 1,Bringing in scraped publications list
+scraped_publications <- sparklyr::sdf_sql(sc, paste("SELECT * FROM", scrape_table_name)) |> collect()
+
+slugs <- unique(scraped_publications$slug)
+
+# COMMAND ----------
+
+# DBTITLE 1,Joining publication info
+# Joining publication info onto the publication specific events
+# TO DO: join to methodology pages too
+downloads <- downloads |>
+  mutate(slug = str_remove(pagePath, "^/find-statistics/")) |>
+  mutate(slug = str_remove(slug, "/.*")) |>
+  mutate(slug = str_remove(slug, "\\.$")) |>
+  left_join(scraped_publications, by = c("slug" = "slug")) |>
+  rename("publication" = title)
+ ## select(date, pagePath, publication, pageviews, sessions)
+
+dates <- create_dates(max(downloads$date))
+
+test_that("There are no missing dates since we started", {
+  expect_equal(
+    setdiff(downloads$date, seq(as.Date(dates$all_time_date), max(dates$latest_date), by = "day")) |>
+      length(),
+    0
+  )
+})
+
+# COMMAND ----------
+
+# selecting just the columns we're interested in storing
+# TO DO: decide if we only want subsets of page_types in here (e.g make it just about publications or remove defunct pages like data catalogue)
+
+downloads <- downloads %>%
+select(date, pagePath, page_type, download_type, publication, eventLabel, eventCount)
+
+# COMMAND ----------
+
+# DBTITLE 1,Write out app data
+updated_spark_df <- copy_to(sc, downloads, overwrite = TRUE)
+
+# Write to temp table while we confirm we're good to overwrite data
+spark_write_table(updated_spark_df, paste0(write_table_name, "_temp"), mode = "overwrite")
+
+temp_table_data <- sparklyr::sdf_sql(sc, paste0("SELECT * FROM ", write_table_name, "_temp")) %>% collect()
+previous_data <- tryCatch(
+  {
+    sparklyr::sdf_sql(sc, paste0("SELECT * FROM ", write_table_name)) %>% collect()
+  },
+  error = function(e) {
+    NULL
+  }
+)
+
+test_that("Temp table data matches updated data", {
+  expect_equal(temp_table_data, downloads)
+})
+
+# Replace the old table with the new one
+dbExecute(sc, paste0("DROP TABLE IF EXISTS ", write_table_name))
+dbExecute(sc, paste0("ALTER TABLE ", write_table_name, "_temp RENAME TO ", write_table_name))
+
+print_changes_summary(temp_table_data, previous_data)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC We're left with the following table 
+# MAGIC
+# MAGIC - **date**: The date the event occured on (earliest date = 21/04/2021)
+# MAGIC - **pagePath**: The pagePath the event occured on
+# MAGIC - **page_type**: Type of service page (Release page, Data catalogue, permalink etc)
+# MAGIC - **download_type**: Type of download (csv, ods, all files etc)
+# MAGIC - **publication**: The publication title (relevant for 'Release page' page_types only atm, need to update code to try and pull in for table tool / data catalogue pages too)
+# MAGIC - **eventLabel**: The info we have for what file was downloaded (this often includes the relevant publication too though is truncated unhelpfully)
+# MAGIC - **eventCount**: The number of downloads of that type on given day
+# MAGIC
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC select page_type, download_type, sum(eventCount)
+# MAGIC from catalog_40_copper_statistics_services.analytics_app.ees_downloads
+# MAGIC group by page_type, download_type
+# MAGIC order by page_type, download_type

--- a/data-updates/notebooks/app_ees_downloads.r
+++ b/data-updates/notebooks/app_ees_downloads.r
@@ -220,11 +220,12 @@ slugs <- unique(scraped_publications$slug)
 
 # DBTITLE 1,Joining publication info
 # Joining publication info onto the publication specific events
-# TO DO: join to methodology pages too
 downloads <- downloads |>
-  mutate(slug = str_remove(pagePath, "^/find-statistics/")) |>
+  mutate(slug = str_remove(pagePath, "^/(find-statistics|data-tables|data-catalogue)/")) |>
   mutate(slug = str_remove(slug, "/.*")) |>
-  mutate(slug = str_remove(slug, "\\.$")) |>
+  mutate(slug = str_trim(slug, side = "both")) |>
+  mutate(slug = str_remove_all(slug, "[^a-zA-Z0-9-]")) |>
+  mutate(slug = str_to_lower(slug)) |>
   left_join(scraped_publications, by = c("slug" = "slug")) |>
   rename("publication" = title)
 
@@ -237,6 +238,13 @@ test_that("There are no missing dates since we started", {
     0
   )
 })
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC select * from
+# MAGIC catalog_40_copper_statistics_services.analytics_app.ees_downloads
+# MAGIC where publication is null
 
 # COMMAND ----------
 
@@ -283,7 +291,8 @@ print_changes_summary(temp_table_data, previous_data)
 # MAGIC - **pagePath**: The pagePath the event occured on
 # MAGIC - **page_type**: Type of service page (Release page, Data catalogue, permalink etc)
 # MAGIC - **download_type**: Type of download (csv, ods, all files etc)
-# MAGIC - **publication**: The publication title (relevant for 'Release page' page_types only atm, need to update code to try and pull in for table tool / data catalogue pages too)
+# MAGIC - **publication**: The publication title (relevant for pages that have an associated publication in their pagePath only)
+# MAGIC TO DO: for some events we can take publicaiton details from the eventLabel and for permalinks we may be able to get publication from a scrape or the EES database - not doing anythign with these atm! 
 # MAGIC - **eventLabel**: The info we have for what file was downloaded (this often includes the relevant publication too though is truncated unhelpfully)
 # MAGIC - **eventCount**: The number of downloads of that type on given day
 # MAGIC

--- a/data-updates/notebooks/app_ees_downloads.r
+++ b/data-updates/notebooks/app_ees_downloads.r
@@ -28,6 +28,9 @@ sc <- spark_connect(method = "databricks")
 # MAGIC - ODS Download Button Clicked (table tool, permalinks)
 # MAGIC - Data Set File Download - All (data catalogue)
 # MAGIC - Release Page File Downloaded (release ancillary)
+# MAGIC - Release Page All Files, Release: Week 8 (and similar across all pubs) (release pages)
+# MAGIC - Data Catalogue Page Selected Files Downl
+# MAGIC
 # MAGIC
 # MAGIC **eventLabel** gives the dataset title
 # MAGIC
@@ -104,7 +107,7 @@ full_data <- sparklyr::sdf_sql(
 
 downloads <- full_data %>% 
   filter(
-    eventName %in% c('CSV Download Button Clicked', 'Data Set File Download', 'Download All Data Button Clicked', 'ODS Download Button Clicked', 'Data Set File Download - All', 'Release Page File Downloaded', 'Excel Download Button Clicked', 'Data Catalogue Page Selected Files Download', 'Release Page All Files Downloaded') | 
+    eventName %in% c('CSV Download Button Clicked', 'Data Set File Download', 'Download All Data Button Clicked', 'ODS Download Button Clicked', 'Data Set File Download - All', 'Release Page File Downloaded', 'Release Page All Files, Release', 'Data Catalogue Page Selected Files Downl', 'Excel Download Button Clicked', 'Data Catalogue Page Selected Files Download', 'Release Page All Files Downloaded') | 
     str_starts(eventName, "Release Page All Files downloads.title, Release:")
   )
 
@@ -142,6 +145,7 @@ downloads <- downloads %>%
     str_detect(eventCategory, "Data Catalogue") ~ "Data catalogue",
     str_detect(eventCategory, "Data Catalogue - Data Set Page") ~ "Data catalogue",
     str_detect(eventName, "Data Catalogue Page Selected Files Download") ~ "Data catalogue",
+    str_detect(eventName, "Data Catalogue Page Selected Files Downl") ~ "Release page",
     
     str_detect(eventCategory, "Permalink Page") ~ "Permalinks",
 
@@ -190,6 +194,7 @@ downloads <- downloads %>%
 
     str_detect(eventName, "Data Set File Download") ~ "Data catalogue",
     str_detect(eventName, "Data Catalogue Page Selected Files Download") ~ "Data catalogue",
+    str_detect(eventName, "Data Catalogue Page Selected Files Downl") ~ "Data catalogue",
 
     str_detect(eventName, "Release Page File Downloaded") ~ "Ancillary",
 
@@ -222,7 +227,6 @@ downloads <- downloads |>
   mutate(slug = str_remove(slug, "\\.$")) |>
   left_join(scraped_publications, by = c("slug" = "slug")) |>
   rename("publication" = title)
- ## select(date, pagePath, publication, pageviews, sessions)
 
 dates <- create_dates(max(downloads$date))
 

--- a/data-updates/notebooks/app_ees_featured_tables.r
+++ b/data-updates/notebooks/app_ees_featured_tables.r
@@ -131,7 +131,6 @@ slugs <- unique(scraped_publications$slug)
 
 # DBTITLE 1,Joining publication info
 # Joining publication info onto the publication specific events
-# TO DO: join to methodology pages too
 featured_table_events <- featured_table_events |>
   mutate(slug = str_remove(pagePath, "^/(data-tables|find-statistics)/")) |>
   mutate(slug = str_remove(slug, "/.*")) |>

--- a/data-updates/notebooks/app_ees_featured_tables.r
+++ b/data-updates/notebooks/app_ees_featured_tables.r
@@ -151,7 +151,6 @@ test_that("There are no missing dates since we started", {
 # COMMAND ----------
 
 # selecting just the columns we're interested in storing
-# TO DO: decide if we only want subsets of page_types in here (e.g make it just about publications or remove defunct pages like data catalogue)
 
 featured_table_events <- featured_table_events %>%
 select(date, pagePath, page_type, publication, eventLabel, eventCount)

--- a/data-updates/notebooks/app_ees_featured_tables.r
+++ b/data-updates/notebooks/app_ees_featured_tables.r
@@ -1,0 +1,199 @@
+# Databricks notebook source
+# DBTITLE 1,Load dependencies
+source("utils.R")
+
+packages <- c("sparklyr", "DBI", "dplyr", "testthat", "arrow", "stringr")
+
+install_if_needed(packages)
+lapply(packages, library, character.only = TRUE)
+
+ga4_event_table_name <- "catalog_40_copper_statistics_services.analytics_raw.ees_ga4_events"
+ua_event_table_name <- "catalog_40_copper_statistics_services.analytics_raw.ees_ua_events"
+scrape_table_name <- "catalog_40_copper_statistics_services.analytics_raw.ees_pub_scrape"
+write_table_name <- "catalog_40_copper_statistics_services.analytics_app.ees_featured_tables"
+
+sc <- spark_connect(method = "databricks")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC
+# MAGIC For featured table events in GA4 we need:
+# MAGIC
+# MAGIC **eventName**
+# MAGIC
+# MAGIC - Clicked to View Featured Table (table tool)
+# MAGIC
+# MAGIC **eventLabel** gives the featured table title
+# MAGIC
+# MAGIC **eventCategory** gives the page the evnt occured on, always the Table Tool in this instance
+# MAGIC
+# MAGIC For search events in UA we need: 
+# MAGIC
+# MAGIC **eventAction**
+# MAGIC - Clicked to View Featured Table (table tool)
+# MAGIC
+# MAGIC **eventLabel** gives the featured table title
+# MAGIC
+# MAGIC **eventCategory** gives the page the evnt occured on, always the Table Tool in this instance
+# MAGIC
+# MAGIC
+
+# COMMAND ----------
+
+# DBTITLE 1,Join the tables together and filter to just accordion relevant events
+
+## I've done this with a group by because otherwise the tests would fail because of duplicates. This could mean I'm just double counting on the day overlap between the two tables - but would need to investigate more to find out.
+
+full_data <- sparklyr::sdf_sql(
+  sc, paste("
+    SELECT 
+      date, 
+      pagePath,
+      eventName,
+      eventLabel,
+      eventCategory,
+      SUM(eventCount) as eventCount
+    FROM (
+      SELECT 
+      date, 
+      pagePath,
+      eventAction as eventName,
+      eventLabel,
+      eventCategory, 
+      totalEvents as eventCount     
+      FROM ", ua_event_table_name, "
+      UNION ALL
+      SELECT 
+      date, 
+      pagePath,
+      eventName,
+      eventLabel,
+      eventCategory,
+      eventCount 
+      FROM ", ga4_event_table_name, "
+    ) AS p
+    GROUP BY date, pagePath, eventName, eventLabel, eventCategory
+    ORDER BY date DESC
+  ")
+) %>% collect()
+
+featured_table_events <- full_data %>% filter(eventName %in% c('Clicked to View Featured Table'))
+
+
+# COMMAND ----------
+
+# DBTITLE 0,Join together and check table integrity
+test_that("No duplicate rows", {
+  expect_true(nrow(featured_table_events) == nrow(dplyr::distinct(featured_table_events)))
+})
+
+test_that("Data has no missing values", {
+  expect_false(any(is.na(featured_table_events)))
+})
+
+dates <- create_dates(max(featured_table_events$date))
+
+test_that("There are no missing dates since we started", {
+  expect_equal(
+    setdiff(featured_table_events$date, seq(as.Date(dates$all_time_date), max(dates$latest_date), by = "day")) |>
+      length(),
+    0
+  )
+})
+
+
+# COMMAND ----------
+
+# DBTITLE 1,Adding a page_type column to help distinguish between different types of search
+featured_table_events <- featured_table_events %>%
+  mutate(page_type = case_when(
+    str_detect(eventCategory, "Table Tool") ~ "Table tool",
+    TRUE ~ 'NA'
+  ))
+
+
+# COMMAND ----------
+
+# DBTITLE 1,Tests
+test_that("There are no events without a page type classification", {
+    expect_true(nrow(featured_table_events %>% filter(page_type =='NA')) == 0)
+    })
+
+# COMMAND ----------
+
+# DBTITLE 1,Bringing in scraped publications list
+scraped_publications <- sparklyr::sdf_sql(sc, paste("SELECT * FROM", scrape_table_name)) |> collect()
+
+slugs <- unique(scraped_publications$slug)
+
+# COMMAND ----------
+
+# DBTITLE 1,Joining publication info
+# Joining publication info onto the publication specific events
+# TO DO: join to methodology pages too
+featured_table_events <- featured_table_events |>
+  mutate(slug = str_remove(pagePath, "^/(data-tables|find-statistics)/")) |>
+  mutate(slug = str_remove(slug, "/.*")) |>
+  mutate(slug = str_remove(slug, "\\.$")) |>
+  left_join(scraped_publications, by = c("slug" = "slug")) |>
+  rename("publication" = title)
+
+dates <- create_dates(max(featured_table_events$date))
+
+test_that("There are no missing dates since we started", {
+  expect_equal(
+    setdiff(featured_table_events$date, seq(as.Date(dates$all_time_date), max(dates$latest_date), by = "day")) |>
+      length(),
+    0
+  )
+})
+
+# COMMAND ----------
+
+# selecting just the columns we're interested in storing
+# TO DO: decide if we only want subsets of page_types in here (e.g make it just about publications or remove defunct pages like data catalogue)
+
+featured_table_events <- featured_table_events %>%
+select(date, pagePath, page_type, publication, eventLabel, eventCount)
+
+# COMMAND ----------
+
+# DBTITLE 1,Write out app data
+updated_spark_df <- copy_to(sc, featured_table_events, overwrite = TRUE)
+
+# Write to temp table while we confirm we're good to overwrite data
+spark_write_table(updated_spark_df, paste0(write_table_name, "_temp"), mode = "overwrite")
+
+temp_table_data <- sparklyr::sdf_sql(sc, paste0("SELECT * FROM ", write_table_name, "_temp")) %>% collect()
+previous_data <- tryCatch(
+  {
+    sparklyr::sdf_sql(sc, paste0("SELECT * FROM ", write_table_name)) %>% collect()
+  },
+  error = function(e) {
+    NULL
+  }
+)
+
+test_that("Temp table data matches updated data", {
+  expect_equal(temp_table_data, featured_table_events)
+})
+
+# Replace the old table with the new one
+dbExecute(sc, paste0("DROP TABLE IF EXISTS ", write_table_name))
+dbExecute(sc, paste0("ALTER TABLE ", write_table_name, "_temp RENAME TO ", write_table_name))
+
+print_changes_summary(temp_table_data, previous_data)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC We're left with the following table 
+# MAGIC
+# MAGIC - **date**: The date the event occured on (earliest date = 21/04/2021)
+# MAGIC - **pagePath**: The pagePath the event occured on
+# MAGIC - **page_type**: Type of service page (Release page, Data catalogue, glossary etc)
+# MAGIC - **publication**: The publication title (relevant for 'Release page' page_types only atm, need to update code to add to methodology pages too)
+# MAGIC - **eventLabel**: The search term used
+# MAGIC - **eventCount**: The number of searches for that term on given day
+# MAGIC

--- a/data-updates/notebooks/app_ees_search_events.r
+++ b/data-updates/notebooks/app_ees_search_events.r
@@ -1,0 +1,229 @@
+# Databricks notebook source
+# DBTITLE 1,Load dependencies
+source("utils.R")
+
+packages <- c("sparklyr", "DBI", "dplyr", "testthat", "arrow", "stringr")
+
+install_if_needed(packages)
+lapply(packages, library, character.only = TRUE)
+
+ga4_event_table_name <- "catalog_40_copper_statistics_services.analytics_raw.ees_ga4_events"
+ua_event_table_name <- "catalog_40_copper_statistics_services.analytics_raw.ees_ua_events"
+scrape_table_name <- "catalog_40_copper_statistics_services.analytics_raw.ees_pub_scrape"
+write_table_name <- "catalog_40_copper_statistics_services.analytics_app.ees_search_events"
+
+sc <- spark_connect(method = "databricks")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC
+# MAGIC For search events in GA4 we need:
+# MAGIC
+# MAGIC **eventName**
+# MAGIC
+# MAGIC - PageSearchForm (used for release and methoodlogy pages)
+# MAGIC - Publications Filtered by Search (used for find stats page)
+# MAGIC - Data Sets Filtered by searchTerm (used for data catalogue)
+# MAGIC
+# MAGIC **eventLabel** gives the search term used
+# MAGIC
+# MAGIC **eventCategory** gives either the page title or slug of the page the search event occured on
+# MAGIC
+# MAGIC NOTE:
+# MAGIC We also have tracking for the following eventName's but are conciously not including them here
+# MAGIC - Reset Search Filter
+# MAGIC - Reset searchTerm Filter
+# MAGIC - Clear Search Filter
+# MAGIC - Clear searchTerm Filter
+# MAGIC
+# MAGIC NOTE: 
+# MAGIC We don't seem to be tracking any searches on the table tool
+# MAGIC
+# MAGIC For search events in UA we need: 
+# MAGIC
+# MAGIC **eventAction**
+# MAGIC - PageSearchForm (used for release and methodology pages -- and /find-stats/ by the looks of things which we might need to check alongside 'Publications Filtered By Search')
+# MAGIC - Publications Filtered by Search (used for find stats page)
+# MAGIC
+# MAGIC **eventLabel** gives the search term used
+# MAGIC
+# MAGIC **eventCategory** gives either the page title or slug of the page the search event occured on
+# MAGIC
+# MAGIC NOTE:
+# MAGIC We also have tracking for the following eventName's but are conciously not including them here
+# MAGIC - Clear Search Filter
+
+# COMMAND ----------
+
+# DBTITLE 1,Join the tables together and filter to just accordion relevant events
+
+## I've done this with a group by because otherwise the tests would fail because of duplicates. This could mean I'm just double counting on the day overlap between the two tables - but would need to investigate more to find out.
+
+full_data <- sparklyr::sdf_sql(
+  sc, paste("
+    SELECT 
+      date, 
+      pagePath,
+      eventName,
+      eventLabel,
+      eventCategory,
+      SUM(eventCount) as eventCount
+    FROM (
+      SELECT 
+      date, 
+      pagePath,
+      eventAction as eventName,
+      eventLabel,
+      eventCategory, 
+      totalEvents as eventCount     
+      FROM ", ua_event_table_name, "
+      UNION ALL
+      SELECT 
+      date, 
+      pagePath,
+      eventName,
+      eventLabel,
+      eventCategory,
+      eventCount 
+      FROM ", ga4_event_table_name, "
+    ) AS p
+    GROUP BY date, pagePath, eventName, eventLabel, eventCategory
+    ORDER BY date DESC
+  ")
+) %>% collect()
+
+search_events <- full_data %>% filter(eventName %in% c('PageSearchForm', 'Publications Filtered by Search', 'Data Sets Filtered by searchTerm'))
+
+
+# COMMAND ----------
+
+# DBTITLE 0,Join together and check table integrity
+test_that("No duplicate rows", {
+  expect_true(nrow(search_events) == nrow(dplyr::distinct(search_events)))
+})
+
+test_that("Data has no missing values", {
+  expect_false(any(is.na(search_events)))
+})
+
+dates <- create_dates(max(search_events$date))
+
+test_that("There are no missing dates since we started", {
+  expect_equal(
+    setdiff(search_events$date, seq(as.Date(dates$all_time_date), max(dates$latest_date), by = "day")) |>
+      length(),
+    0
+  )
+})
+
+
+# COMMAND ----------
+
+# DBTITLE 1,Adding a page_type column to help distinguish between different types of search
+search_events <- search_events %>%
+  mutate(page_type = case_when(
+    str_detect(eventCategory, "/Find-Statistics/") ~ "Release page",
+    
+    str_detect(eventCategory, "Find Statistics and Data") ~ "Find stats",
+    str_detect(eventCategory, "/Find-Statistics") ~ "Find stats",
+    
+    str_detect(eventCategory, "Glossary") ~ "Glossary",
+
+    str_detect(eventCategory, "Data Catalogue") ~ "Data catalogue",
+    str_detect(eventCategory, "/Data-Catalogue/") ~ "Data catalogue",
+    str_detect(eventCategory, "/Download-Latest-Data") ~ "Data catalogue",
+
+    str_detect(eventCategory, "/Methodology/") ~ "Methodology pages",
+    str_detect(eventCategory, "/Methodology") ~ "Methodology nav",
+
+    str_detect(eventCategory, "/Data-Tables/") ~ "Table tool",
+    TRUE ~ 'NA'
+  ))
+
+
+# COMMAND ----------
+
+# DBTITLE 1,Tests
+test_that("There are no events without a page type classification", {
+    expect_true(nrow(search_events %>% filter(page_type =='NA')) == 0)
+    })
+
+# COMMAND ----------
+
+# DBTITLE 1,Bringing in scraped publications list
+scraped_publications <- sparklyr::sdf_sql(sc, paste("SELECT * FROM", scrape_table_name)) |> collect()
+
+slugs <- unique(scraped_publications$slug)
+
+# COMMAND ----------
+
+# DBTITLE 1,Joining publication info
+# Joining publication info onto the publication specific events
+# TO DO: join to methodology pages too
+search_events <- search_events |>
+  mutate(slug = str_remove(pagePath, "^/find-statistics/")) |>
+  mutate(slug = str_remove(slug, "/.*")) |>
+  mutate(slug = str_remove(slug, "\\.$")) |>
+  left_join(scraped_publications, by = c("slug" = "slug")) |>
+  rename("publication" = title)
+ ## select(date, pagePath, publication, pageviews, sessions)
+
+dates <- create_dates(max(search_events$date))
+
+test_that("There are no missing dates since we started", {
+  expect_equal(
+    setdiff(search_events$date, seq(as.Date(dates$all_time_date), max(dates$latest_date), by = "day")) |>
+      length(),
+    0
+  )
+})
+
+# COMMAND ----------
+
+# selecting just the columns we're interested in storing
+# TO DO: decide if we only want subsets of page_types in here (e.g make it just about publications or remove defunct pages like data catalogue)
+
+search_events <- search_events %>%
+select(date, pagePath, page_type, publication, eventLabel, eventCount)
+
+# COMMAND ----------
+
+# DBTITLE 1,Write out app data
+updated_spark_df <- copy_to(sc, search_events, overwrite = TRUE)
+
+# Write to temp table while we confirm we're good to overwrite data
+spark_write_table(updated_spark_df, paste0(write_table_name, "_temp"), mode = "overwrite")
+
+temp_table_data <- sparklyr::sdf_sql(sc, paste0("SELECT * FROM ", write_table_name, "_temp")) %>% collect()
+previous_data <- tryCatch(
+  {
+    sparklyr::sdf_sql(sc, paste0("SELECT * FROM ", write_table_name)) %>% collect()
+  },
+  error = function(e) {
+    NULL
+  }
+)
+
+test_that("Temp table data matches updated data", {
+  expect_equal(temp_table_data, search_events)
+})
+
+# Replace the old table with the new one
+dbExecute(sc, paste0("DROP TABLE IF EXISTS ", write_table_name))
+dbExecute(sc, paste0("ALTER TABLE ", write_table_name, "_temp RENAME TO ", write_table_name))
+
+print_changes_summary(temp_table_data, previous_data)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC We're left with the following table 
+# MAGIC
+# MAGIC - **date**: The date the event occured on (earliest date = 21/04/2021)
+# MAGIC - **pagePath**: The pagePath the event occured on
+# MAGIC - **page_type**: Type of service page (Release page, Data catalogue, glossary etc)
+# MAGIC - **publication**: The publication title (relevant for 'Release page' page_types only atm, need to update code to add to methodology pages too)
+# MAGIC - **eventLabel**: The search term used
+# MAGIC - **eventCount**: The number of searches for that term on given day
+# MAGIC

--- a/data-updates/notebooks/app_ees_search_events.r
+++ b/data-updates/notebooks/app_ees_search_events.r
@@ -160,14 +160,15 @@ slugs <- unique(scraped_publications$slug)
 
 # DBTITLE 1,Joining publication info
 # Joining publication info onto the publication specific events
-# TO DO: join to methodology pages too
 search_events <- search_events |>
-  mutate(slug = str_remove(pagePath, "^/find-statistics/")) |>
+  mutate(slug = str_remove(pagePath, "^/(methodology|find-statistics|data-catalogue|data-tables)/")) |>
+  mutate(slug = str_remove(slug, "-methodology")) |>
   mutate(slug = str_remove(slug, "/.*")) |>
+  mutate(slug = str_trim(slug, side = "both")) |>
   mutate(slug = str_remove(slug, "\\.$")) |>
+  mutate(slug = str_to_lower(slug)) |>
   left_join(scraped_publications, by = c("slug" = "slug")) |>
   rename("publication" = title)
- ## select(date, pagePath, publication, pageviews, sessions)
 
 dates <- create_dates(max(search_events$date))
 
@@ -185,7 +186,7 @@ test_that("There are no missing dates since we started", {
 # TO DO: decide if we only want subsets of page_types in here (e.g make it just about publications or remove defunct pages like data catalogue)
 
 search_events <- search_events %>%
-select(date, pagePath, page_type, publication, eventLabel, eventCount)
+select(date, pagePath, page_type, publication, eventLabel, eventCount,slug)
 
 # COMMAND ----------
 
@@ -223,7 +224,7 @@ print_changes_summary(temp_table_data, previous_data)
 # MAGIC - **date**: The date the event occured on (earliest date = 21/04/2021)
 # MAGIC - **pagePath**: The pagePath the event occured on
 # MAGIC - **page_type**: Type of service page (Release page, Data catalogue, glossary etc)
-# MAGIC - **publication**: The publication title (relevant for 'Release page' page_types only atm, need to update code to add to methodology pages too)
+# MAGIC - **publication**: The publication title (relevant for pages that have an associated methodology only)
 # MAGIC - **eventLabel**: The search term used
 # MAGIC - **eventCount**: The number of searches for that term on given day
 # MAGIC

--- a/data-updates/notebooks/app_ees_search_events.r
+++ b/data-updates/notebooks/app_ees_search_events.r
@@ -186,7 +186,7 @@ test_that("There are no missing dates since we started", {
 # TO DO: decide if we only want subsets of page_types in here (e.g make it just about publications or remove defunct pages like data catalogue)
 
 search_events <- search_events %>%
-select(date, pagePath, page_type, publication, eventLabel, eventCount,slug)
+select(date, pagePath, page_type, publication, eventLabel, eventCount)
 
 # COMMAND ----------
 
@@ -224,7 +224,7 @@ print_changes_summary(temp_table_data, previous_data)
 # MAGIC - **date**: The date the event occured on (earliest date = 21/04/2021)
 # MAGIC - **pagePath**: The pagePath the event occured on
 # MAGIC - **page_type**: Type of service page (Release page, Data catalogue, glossary etc)
-# MAGIC - **publication**: The publication title (relevant for pages that have an associated methodology only)
+# MAGIC - **publication**: The publication title (relevant for pages that have an associated publication only)
 # MAGIC - **eventLabel**: The search term used
 # MAGIC - **eventCount**: The number of searches for that term on given day
 # MAGIC

--- a/data-updates/notebooks/raw_ees_pub_scrape.r
+++ b/data-updates/notebooks/raw_ees_pub_scrape.r
@@ -218,8 +218,3 @@ if (!is.null(previous_data)) {
 # Replace the old table with the new one
 dbExecute(sc, paste0("DROP TABLE IF EXISTS ", write_table_name))
 dbExecute(sc, paste0("ALTER TABLE ", write_table_name, "_temp RENAME TO ", write_table_name))
-
-# COMMAND ----------
-
-# MAGIC %sql
-# MAGIC select * from catalog_40_copper_statistics_services.analytics_raw.ees_pub_scrape

--- a/data-updates/notebooks/raw_ees_pub_scrape.r
+++ b/data-updates/notebooks/raw_ees_pub_scrape.r
@@ -81,6 +81,72 @@ test_that("Number of rows is more than find stats results", {
 # COMMAND ----------
 
 # MAGIC %md
+# MAGIC The following methodology slugs don't have an exact or ditinct match to a publication slug. To avoid null publication details across analytics tables we want to force the main publication in to each, I went to each manually to find the associated publication and then copied the publication title in for each.
+# MAGIC
+# MAGIC - slug == "schools-pupils-and-their-characteristics" & title == "Schools, pupils and their characteristics"
+# MAGIC - slug == "technical-documentation-2022" & title == "Employer Skills Survey"
+# MAGIC - slug == "pupil-exclusion-statistics" & title == "Suspensions and permanent exclusions in England"
+# MAGIC - slug == "further-education-and-skills-statistics" & title == "Further education and skills"
+# MAGIC - slug == "level-2-and-3-attainment-age-16-to-25" & title == "Level 2 and 3 attainment age 16 to 25"
+# MAGIC - slug == "education-provision-children-under-5-years-of-age" & title == "Education provision: children under 5 years of age"
+# MAGIC - slug == "school-admission-appeals-in-england" & title == "Admission appeals in England"
+# MAGIC - slug == "children-accommodated-in-secure-children-s-homes" & title == "Children accommodated in secure children's homes"
+# MAGIC - slug == "education-children-s-social-care-and-offending-descriptive-statistics-technical-note" & title == "Education, children’s social care and offending: local authority level dashboard"
+# MAGIC - slug == "graduate-labour-market-statistics" & title == "Graduate labour market statistics"
+# MAGIC - slug == "national-tutoring-programme-statistics" & title == "National Tutoring Programme"
+# MAGIC - slug == "participation-in-education-training-and-employment-age-16-to-18" & title == "Participation in education, training and employment age 16 to 18"
+# MAGIC - slug == "progression-to-higher-education-and-training" & title == "Progression to higher education or training"
+# MAGIC - slug == "pupil-absence-statistics" & title == "Pupil absence in schools in England"
+# MAGIC - slug == "school-workforce-in-england-methodolgy" & title == "School workforce in England"
+# MAGIC
+# MAGIC Will add these as rows manually to end of combined_scrape
+
+# COMMAND ----------
+
+new_rows <- data.frame(
+  slug = c(
+    "schools-pupils-and-their-characteristics",
+    "technical-documentation-2022",
+    "pupil-exclusion-statistics",
+    "further-education-and-skills-statistics",
+    "level-2-and-3-attainment-age-16-to-25",
+    "education-provision-children-under-5-years-of-age",
+    "school-admission-appeals-in-england",
+    "children-accommodated-in-secure-children-s-homes",
+    "education-children-s-social-care-and-offending-descriptive-statistics-technical-note",
+    "graduate-labour-market-statistics",
+    "national-tutoring-programme-statistics",
+    "participation-in-education-training-and-employment-age-16-to-18",
+    "progression-to-higher-education-and-training",
+    "pupil-absence-statistics",
+    "school-workforce-in-england-methodolgy"
+  ),
+  title = c(
+    "Schools, pupils and their characteristics",
+    "Employer Skills Survey",
+    "Suspensions and permanent exclusions in England",
+    "Further education and skills",
+    "Level 2 and 3 attainment age 16 to 25",
+    "Education provision: children under 5 years of age",
+    "Admission appeals in England",
+    "Children accommodated in secure children's homes",
+    "Education, children’s social care and offending: local authority level dashboard",
+    "Graduate labour market statistics",
+    "National Tutoring Programme",
+    "Participation in education, training and employment age 16 to 18",
+    "Progression to higher education or training",
+    "Pupil absence in schools in England",
+    "School workforce in England"
+  )
+)
+
+# Append the new rows to the existing data frame
+combined_scrape <- bind_rows(combined_scrape, new_rows) |>
+  distinct()
+
+# COMMAND ----------
+
+# MAGIC %md
 # MAGIC TODO: Move this next section out once we have a lookup table to rely on for renaming
 # MAGIC
 # MAGIC Current known renames that appear as duplicates unless handled (i.e. we have more than one title for a given slug):
@@ -140,7 +206,7 @@ previous_data <- tryCatch(
 )
 
 if (!is.null(previous_data)) {
-  test_that("Number of pub / slug combos is less than 10% more than previous", {
+  test_that("Number of pub / slug combos has not increased by more than 10%", {
     expect_lt(nrow(temp_table_data), nrow(previous_data) * 1.1)
   })
 
@@ -152,3 +218,8 @@ if (!is.null(previous_data)) {
 # Replace the old table with the new one
 dbExecute(sc, paste0("DROP TABLE IF EXISTS ", write_table_name))
 dbExecute(sc, paste0("ALTER TABLE ", write_table_name, "_temp RENAME TO ", write_table_name))
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC select * from catalog_40_copper_statistics_services.analytics_raw.ees_pub_scrape


### PR DESCRIPTION
## Overview of changes

So far have added basic versions of tidier events data for 
- Accordions
- Searches
- Downloads
- Featured tables

When we're developing the app we may want to consider chopping the tables down a bit smaller (to specific page_types for example) but for now this just tried to cover the legwork in getting relevant datasets ready. 

## Why are these changes being made?

To support adding extra breakdowns to the analytics app

## Checklist

- [ ] I have ran `styler::style_dir()`
- [ ] I have ran `lintr::lint_dir()`
- [ ] I have updated the documentation
- [ ] I have added or updated automated tests for these changes

## Reviewer instructions

