### PR TITLE
add raw hourly data and a quick notebook to pull off charts

### DIFF
--- a/adhoc-scripts/ees-hours-days-months.r
+++ b/adhoc-scripts/ees-hours-days-months.r
@@ -1,0 +1,158 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC A few quick summaries of the usage on EES, breaking down by the most popular hours, days and months
+
+# COMMAND ----------
+
+# DBTITLE 1,Set up dependencies
+options(repos = c(CRAN = "https://packagemanager.posit.co/cran/__linux__/focal/latest"))
+
+if (!requireNamespace("pak", quietly = TRUE)) {
+  install.packages("pak")
+}
+
+pkgs <- c("sparklyr", "arrow", "dplyr", "ggplot2", "afcharts", "stringr")
+
+to_install <- pkgs[!sapply(pkgs, requireNamespace, quietly = TRUE)]
+
+if (length(to_install) > 0) {
+  pak::pkg_install(to_install, ask = FALSE)
+} else {
+  message("Skipping install... all packages already installed")
+}
+
+lapply(pkgs, library, character.only = TRUE)
+
+catalog <- "catalog_40_copper_statistics_services."
+schema <- "analytics_raw."
+
+sc <- spark_connect(method = "databricks")
+
+# COMMAND ----------
+
+# DBTITLE 1,By month
+monthly_breakdown <- sparklyr::sdf_sql(sc, paste0("
+  SELECT 
+  DATE_FORMAT(date, 'MMMM') AS month,
+  SUM(sessions) AS sessions
+FROM 
+  (SELECT date, sessions FROM ", catalog, schema, "ees_ga4_service_summary
+   UNION ALL
+   SELECT date, sessions FROM ", catalog, schema, "ees_ua_service_summary) AS combined_summary
+WHERE
+  YEAR(date) in (2021,2022,2023,2024)
+GROUP BY 
+  DATE_FORMAT(date, 'MMMM'),
+  MONTH(date)
+ORDER BY 
+  MONTH(date);
+")) |> 
+  collect()
+
+ggplot(monthly_breakdown, aes(x = sessions, y = factor(month, levels = rev(month.name)))) +
+  geom_col(fill = af_colour_values["dark-blue"]) +
+  theme_af(grid = "none", axis = "none") +
+  geom_text(aes(label = scales::comma(sessions)), color = "white", position = position_stack(vjust = 0), hjust = -0.15) +
+  labs(
+    x = NULL,
+    y = NULL,
+    title = "November is our busiest month",
+    subtitle = stringr::str_wrap(
+      "Total number of sessions on explore education statistics by month, 2021-2024 inclusive",
+      60
+    ),
+    caption = "Source: Google Universal Analytics and Google Analytics 4"
+  ) +
+  theme(plot.caption = element_text(margin = margin(t = 20))) +
+  theme(plot.margin = unit(c(1, 5, 1, 0.5), "cm")) +
+  theme(axis.text.x = element_blank()) +
+  theme(axis.line.y = element_blank())
+
+# COMMAND ----------
+
+# DBTITLE 1,By day
+daily_breakdown <- sparklyr::sdf_sql(sc, paste0("
+  SELECT
+  DATE_FORMAT(date, 'EEEE') AS day_of_week,
+  AVG(sessions) AS sessions
+FROM
+  (
+    SELECT
+      date,
+      sessions
+    FROM
+      ", catalog, schema, "ees_ga4_service_summary
+    UNION ALL
+    SELECT
+      date,
+      sessions
+    FROM
+      ", catalog, schema, "ees_ua_service_summary
+  ) AS combined_summary
+GROUP BY
+  DATE_FORMAT(date, 'EEEE')
+ORDER BY
+  CASE DATE_FORMAT(date, 'EEEE')
+    WHEN 'Sunday' THEN 1
+    WHEN 'Monday' THEN 2
+    WHEN 'Tuesday' THEN 3
+    WHEN 'Wednesday' THEN 4
+    WHEN 'Thursday' THEN 5
+    WHEN 'Friday' THEN 6
+    WHEN 'Saturday' THEN 7
+  END;
+")) |> 
+  collect()
+
+ggplot(daily_breakdown, aes(x = sessions, y = factor(day_of_week, levels = rev(c("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"))))) +
+  geom_col(fill = af_colour_values["dark-blue"]) +
+  theme_af(grid = "none", axis = "none") +
+  geom_text(aes(label = scales::comma(sessions)), color = "white", position = position_stack(vjust = 0), hjust = -0.15) +
+  labs(
+    x = NULL,
+    y = NULL,
+    title = "Tuesday pips Thursday as our busiest day",
+    subtitle = stringr::str_wrap(
+      "Average sessions on explore education statistics by day, all time",
+      60
+    ),
+    caption = "Source: Google Universal Analytics and Google Analytics 4"
+  ) +
+  theme(plot.caption = element_text(margin = margin(t = 20))) +
+  theme(plot.margin = unit(c(1, 5, 1, 0.5), "cm")) +
+  theme(axis.text.x = element_blank()) +
+  theme(axis.line.y = element_blank())
+
+# COMMAND ----------
+
+# DBTITLE 1,By hour
+hourly_breakdown <- sparklyr::sdf_sql(sc, paste0("
+  SELECT 
+    cast(hour as int), 
+    sum(sessions) as sessions 
+  FROM ", catalog, schema, "ees_ga4_hourly 
+  GROUP BY hour 
+  ORDER BY hour;
+")) |> 
+  collect() |>
+  filter(!is.na(hour))
+
+ggplot(hourly_breakdown, aes(x = sessions, y = factor(hour, levels = rev(0:23), labels = sprintf("%02d:00", rev(0:23))))) +
+  geom_col(fill = af_colour_values["dark-blue"]) +
+  theme_af(grid = "none", axis = "none") +
+  geom_text(aes(label = scales::comma(sessions)), color = "black", position = position_stack(vjust = 1), hjust = -0.1) +
+  labs(
+    x = NULL,
+    y = NULL,
+    title = "Interest peaks at 10am and 2pm",
+    subtitle = stringr::str_wrap(
+      "Active sessions by hour on explore education statistics, since 2022",
+      60
+    ),
+    caption = "Source: Google Analytics 4"
+  ) +
+  theme(plot.caption = element_text(margin = margin(t = 20))) +
+  theme(plot.margin = unit(c(1, 5, 1, 0.5), "cm")) +
+  theme(axis.text.x = element_blank()) +
+  theme(axis.line.y = element_blank()) +
+  coord_cartesian(xlim = c(0, max(hourly_breakdown$sessions) * 1.2))

--- a/data-updates/notebooks/raw_ees_hourly.r
+++ b/data-updates/notebooks/raw_ees_hourly.r
@@ -1,0 +1,129 @@
+# Databricks notebook source
+source("utils.R")
+
+packages <- c(
+  "googleAnalyticsR",
+  "googleAuthR",
+  "sparklyr",
+  "DBI",
+  "dplyr",
+  "tidyr",
+  "testthat",
+  "lubridate",
+  "arrow"
+)
+
+install_if_needed(packages)
+lapply(packages, library, character.only = TRUE)
+
+table_name <- "catalog_40_copper_statistics_services.analytics_raw.ees_ga4_hourly"
+
+sc <- spark_connect(method = "databricks")
+
+# COMMAND ----------
+
+ga_auth(json = auth_path)
+
+# COMMAND ----------
+
+dbExecute(sc, paste(
+  "CREATE TABLE IF NOT EXISTS",
+  table_name,
+  "(date DATE, hour DOUBLE, sessions DOUBLE)"
+))
+
+last_date <- sparklyr::sdf_sql(sc, paste("SELECT MAX(date) FROM", table_name)) %>%
+  collect() %>%
+  pull() %>%
+  as.character()
+
+if (is.na(last_date)) {
+  # Before tracking started so gets the whole series that is available
+  last_date <- "2022-02-02"
+}
+
+reference_dates <- create_dates(Sys.Date() - 2) # doing this to make sure the data is complete when we request it
+
+changes_since <- as.Date(last_date) + 1
+changes_to <- as.Date(reference_dates$latest_date)
+
+test_that("Query dates are valid", {
+  expect_true(is.Date(changes_since))
+  expect_true(grepl("\\d{4}-\\d{2}-\\d{2}", as.character(changes_since)))
+  expect_true(is.Date(changes_to))
+  expect_true(grepl("\\d{4}-\\d{2}-\\d{2}", as.character(changes_to)))
+
+  if (changes_to < changes_since) {
+    # Exit the notebook early
+    dbutils.notebook.exit("Data is up to date, skipping the rest of the notebook")
+  }
+})
+
+# COMMAND ----------
+
+previous_data <- sparklyr::sdf_sql(sc, paste("SELECT * FROM", table_name)) %>% collect()
+
+latest_data <- ga_data(
+  369420610,
+  metrics = c("sessions"),
+  dimensions = c("date", "hour"),
+  date_range = c(changes_since, changes_to),
+  limit = -1
+)
+
+# COMMAND ----------
+
+test_that("Col names match", {
+  if (length(names(previous_data)) != 0) {
+    expect_equal(names(latest_data), names(previous_data))
+  }
+})
+
+updated_data <- rbind(previous_data, latest_data) |>
+  dplyr::arrange(desc(date)) |>
+  tidyr::drop_na()
+
+# COMMAND ----------
+
+test_that("New data has more rows than previous data", {
+  expect_true(nrow(updated_data) > nrow(previous_data))
+})
+
+test_that("New data has no duplicate rows", {
+  expect_true(nrow(updated_data) == nrow(dplyr::distinct(updated_data)))
+})
+
+test_that("Latest date is as expected", {
+  expect_equal(updated_data$date[1], changes_to)
+})
+
+test_that("Data has no missing values", {
+  expect_false(any(is.na(updated_data)))
+})
+
+test_that("There are no missing dates since we started GA4", {
+  expect_equal(
+    setdiff(updated_data$date, seq(as.Date(reference_dates$ga4_date), changes_to, by = "day")) |>
+      length(),
+    0
+  )
+})
+
+# COMMAND ----------
+
+ga4_spark_df <- copy_to(sc, updated_data, overwrite = TRUE)
+
+# Write to temp table while we confirm we're good to overwrite data
+spark_write_table(ga4_spark_df, paste0(table_name, "_temp"), mode = "overwrite")
+
+temp_table_data <- sparklyr::sdf_sql(sc, paste0("SELECT * FROM ", table_name, "_temp")) %>% collect()
+
+test_that("Temp table data matches updated data", {
+  expect_equal(nrow(temp_table_data), nrow(updated_data))
+})
+
+# Replace the old table with the new one
+dbExecute(sc, paste0("DROP TABLE IF EXISTS ", table_name))
+dbExecute(sc, paste0("ALTER TABLE ", table_name, "_temp RENAME TO ", table_name))
+
+print_changes_summary(temp_table_data, previous_data)


### PR DESCRIPTION
## Overview of changes

- Add a new hourly raw table (purely to be able to view the peaks of our traffic across a day)
- Add a new notebook for generating the hourly raw table
- Add an ad hoc notebook for getting hourly / daily / monthly summaries

## Why are these changes being made?

Decided we didn't need the hourly / monthly / daily breakdowns in the app yet, but might be handy to be able to pull off from time to time.

## Checklist

- [ ] I have ran `styler::style_dir()`
- [ ] I have ran `lintr::lint_dir()`
- [ ] I have updated the documentation
- [ ] I have added or updated automated tests for these changes

## Reviewer instructions

Test out running the ad hoc notebook