### PR TITLE
add rolling averages (and fallback mirror)

### DIFF
--- a/data-updates/notebooks/app_ees_release_pageviews.r
+++ b/data-updates/notebooks/app_ees_release_pageviews.r
@@ -2,7 +2,7 @@
 # DBTITLE 1,Load dependencies
 source("utils.R")
 
-packages <- c("sparklyr", "DBI", "dplyr", "testthat", "arrow", "stringr", "TTR")
+packages <- c("sparklyr", "DBI", "dplyr", "testthat", "arrow", "stringr")
 
 install_if_needed(packages)
 lapply(packages, library, character.only = TRUE)
@@ -35,14 +35,6 @@ test_that("No duplicate rows", {
 test_that("Data has no missing values", {
   expect_false(any(is.na(sql_data)))
 })
-
-# Create rolling averages (simple moving average)
-aggregated_data <- aggregated_data %>%
-  arrange(date) %>%
-  mutate(
-    pageviews_avg7 = TTR::SMA(pageviews, n = 7),
-    sessions_avg7 = TTR::SMA(sessions, n = 7)    
-  )
 
 dates <- create_dates(max(sql_data$date))
 

--- a/data-updates/notebooks/app_ees_release_pageviews.r
+++ b/data-updates/notebooks/app_ees_release_pageviews.r
@@ -2,7 +2,7 @@
 # DBTITLE 1,Load dependencies
 source("utils.R")
 
-packages <- c("sparklyr", "DBI", "dplyr", "testthat", "arrow", "stringr")
+packages <- c("sparklyr", "DBI", "dplyr", "testthat", "arrow", "stringr", "TTR")
 
 install_if_needed(packages)
 lapply(packages, library, character.only = TRUE)
@@ -35,6 +35,14 @@ test_that("No duplicate rows", {
 test_that("Data has no missing values", {
   expect_false(any(is.na(sql_data)))
 })
+
+# Create rolling averages (simple moving average)
+aggregated_data <- aggregated_data %>%
+  arrange(date) %>%
+  mutate(
+    pageviews_avg7 = TTR::SMA(pageviews, n = 7),
+    sessions_avg7 = TTR::SMA(sessions, n = 7)    
+  )
 
 dates <- create_dates(max(sql_data$date))
 

--- a/data-updates/notebooks/app_ees_service_summary.r
+++ b/data-updates/notebooks/app_ees_service_summary.r
@@ -2,7 +2,7 @@
 # DBTITLE 1,Load dependencies
 source("utils.R")
 
-packages <- c("sparklyr", "DBI", "dplyr", "testthat", "arrow")
+packages <- c("sparklyr", "DBI", "dplyr", "testthat", "arrow" , "TTR")
 
 install_if_needed(packages)
 lapply(packages, library, character.only = TRUE)
@@ -24,19 +24,28 @@ sc <- spark_connect(method = "databricks")
 # DBTITLE 1,Join together and check table integrity
 aggregated_data <- sparklyr::sdf_sql(
   sc, paste("
-    SELECT date, pageviews as screenPageViews, sessions, avg_session_duration as averageSessionDuration FROM", ua_service_table_name, "
+    SELECT date, pageviews, sessions, avg_session_duration as averageSessionDuration FROM", ua_service_table_name, "
       UNION ALL
-    SELECT date, screenPageViews, sessions, averageSessionDuration FROM", ga4_service_table_name, "
+    SELECT date, screenPageViews as pageviews, sessions, averageSessionDuration FROM", ga4_service_table_name, "
     ORDER BY date DESC;
   ")
 ) %>% collect()
+
+# Create rolling averages (simple moving average)
+aggregated_data <- aggregated_data %>%
+  arrange(date) %>%
+  mutate(
+    pageviews_avg7 = TTR::SMA(pageviews, n = 7),
+    sessions_avg7 = TTR::SMA(sessions, n = 7)    
+  )
 
 test_that("No duplicate rows", {
   expect_true(nrow(aggregated_data) == nrow(dplyr::distinct(aggregated_data)))
 })
 
 test_that("Data has no missing values", {
-  expect_false(any(is.na(aggregated_data)))
+  # We expect the rolling average cols to have some missing values so ignoring for this
+  expect_false(any(is.na(aggregated_data |> select(-c(pageviews_avg7, sessions_avg7))))) 
 })
 
 dates <- create_dates(max(aggregated_data$date))

--- a/data-updates/notebooks/utils.R
+++ b/data-updates/notebooks/utils.R
@@ -1,6 +1,12 @@
 # focal seems to be the ubuntu that my current cluster is running (runtime 15.4)
 mirror_date <- "14/02/2025" # can use to freeze versions of dependencies
-options(repos = c(CRAN = paste0("https://packagemanager.posit.co/cran/__linux__/focal/", mirror_date)))
+options(
+  repos = c(
+    # Get prepackaged binaries for speed where possible
+    linuxBinaries = paste0("https://packagemanager.posit.co/cran/__linux__/focal/", mirror_date),
+    fallbackCRAN = "https://cloud.r-project.org"
+  )
+)
 
 # Function to use pak to install packages that aren't already installed
 install_if_needed <- function(pkg) {


### PR DESCRIPTION
## Overview of changes

Used the TTR package to add in a 7 day rolling average.

## Why are these changes being made?

We wanted to test out plotting a 7 day rolling average for service usage, the TTR package wasn't found on the mirror we were using so I've added CRAN as a fallback incase it's needed.

## Checklist

<!-- Put 'x' in the checkboxes that you have completed to help your reviewer -->

- [ ] I have ran `styler::style_dir()`
- [ ] I have ran `lintr::lint_dir()`
- [ ] I have updated the documentation
- [ ] I have added or updated automated tests for these changes

## Reviewer instructions

Will need to rebase this after #10 has gone in