### PR TITLE
Read rows direct from spark instead of collecting to R

### DIFF
--- a/data-updates/notebooks/raw_ees_search_console.r
+++ b/data-updates/notebooks/raw_ees_search_console.r
@@ -147,10 +147,10 @@ ga4_spark_df <- copy_to(sc, updated_data, overwrite = TRUE)
 # Write to temp table while we confirm we're good to overwrite data
 spark_write_table(ga4_spark_df, paste0(table_name, "_temp"), mode = "overwrite")
 
-temp_table_data <- sparklyr::sdf_sql(sc, paste0("SELECT * FROM ", table_name, "_temp")) %>% collect()
+temp_table_data <- sparklyr::sdf_sql(sc, paste0("SELECT * FROM ", table_name, "_temp"))
 
 test_that("Temp table data matches updated data", {
-  expect_equal(nrow(temp_table_data), nrow(updated_data))
+ expect_equal(sdf_nrow(temp_table_data), nrow(updated_data)) # No collect()
 })
 
 # Replace the old table with the new one


### PR DESCRIPTION
## Overview of changes

Saves the need to read the full table into R just to check the row number, instead we can do this direct from spark.

## Why are these changes being made?

Quick one suggested by the databricks team while they were investigating the hanging issue. Should save some unnecessary processing.

## Checklist

<!-- Put 'x' in the checkboxes that you have completed to help your reviewer -->

- [ ] I have ran `styler::style_dir()`
- [ ] I have ran `lintr::lint_dir()`
- [ ] I have updated the documentation
- [ ] I have added or updated automated tests for these changes

## Reviewer instructions

Nothing specific, mostly just a cursory glance that there's nothing crazy in this, the notebook will be executed each weekday as a part of the regularly workflow.

Example manually triggered run, ran without issue:

...