### PR TITLE
use spark df instead of collecting into R

### DIFF
--- a/data-updates/notebooks/utils.R
+++ b/data-updates/notebooks/utils.R
@@ -64,6 +64,30 @@ print_changes_summary <- function(new_table, old_table) {
   }
 }
 
+# Temporary second function for notebooks making more use of sdf dataframes
+# Eventually should migrate all notebooks to match raw_search_console and use this, removing original function above
+sdf_print_changes_summary <- function(new_table, old_table){
+  if (is.null(old_table)) {
+    message("New table summary...")
+    message("Number of rows: ", sdf_nrow(new_table))
+    message("Column names: ", paste(colnames(new_table), collapse = ", "))
+  } else {
+    new_dates <- as.Date(
+      setdiff(
+        temp_table_data %>% sdf_distinct("date") %>% sdf_read_column("date"), 
+        previous_data %>% sdf_distinct("date") %>% sdf_read_column("date")
+      )
+    )
+    new_rows <- sdf_nrow(new_table) - sdf_nrow(old_table)
+
+    message("Updated table summary...")
+    message("New rows: ", new_rows)
+    message("New dates: ", paste(new_dates, collapse = ","))
+    message("Total rows: ", sdf_nrow(new_table), " rows")
+    message("Column names: ", paste(colnames(new_table), collapse = ", "))
+  }
+}
+
 # Scraping helpers -------------------------------------------------------------------
 scrape_publications <- function(url) {
   rvest::read_html(url) |>


### PR DESCRIPTION
## Overview of changes

Changing the search console API querying notebook to use the spark data frame more, rather than relying on in memory R processing.

## Why are these changes being made?

Recommended optimisation to avoid using `copy_to()` on a table that has around 7 million rows, as all the main processing is done in spark now, in theory this should run smoother.

## Checklist

- [ ] I have ran `styler::style_dir()`
- [ ] I have ran `lintr::lint_dir()`
- [ ] I have updated the documentation
- [ ] I have added or updated automated tests for these changes

## Reviewer instructions

Nothing specific - will just merge so we can see how it runs overnight tonight.

Tested this by deleting the most recent rows from the database and re-running, seemed to work fine and relatively speedily, main bottleneck is the search console API call itself.