### PR TITLE
Move to just keeping raw events table in spark

### DIFF
--- a/data-updates/notebooks/raw_ees_ga4_events.r
+++ b/data-updates/notebooks/raw_ees_ga4_events.r
@@ -68,7 +68,7 @@ test_that("Query dates are valid", {
 # COMMAND ----------
 
 # DBTITLE 1,Get previous data
-previous_data <- sparklyr::sdf_sql(sc, paste("SELECT * FROM", table_name)) %>% collect()
+previous_data <- sparklyr::sdf_sql(sc, paste("SELECT * FROM", table_name))
 
 # COMMAND ----------
 
@@ -87,8 +87,10 @@ latest_data <- ga_data(
 
 # DBTITLE 1,Append new data onto old
 test_that("Col names match", {
-  expect_equal(names(latest_data), names(previous_data))
+  expect_equal(names(latest_data), colnames(previous_data)) # colnames is the spark_df equivalent of names
 })
+
+latest_data <- copy_to(sc, latest_data, overwrite = TRUE)
 
 updated_data <- rbind(previous_data, latest_data) |>
   dplyr::arrange(desc(date)) |>
@@ -98,15 +100,21 @@ updated_data <- rbind(previous_data, latest_data) |>
 
 # DBTITLE 1,Quick data integrity checks
 test_that("New data has more rows than previous data", {
-  expect_true(nrow(updated_data) > nrow(previous_data))
+  expect_true(sdf_nrow(updated_data) > sdf_nrow(previous_data))
 })
 
 test_that("New data has no duplicate rows", {
-  expect_true(nrow(updated_data) == nrow(dplyr::distinct(updated_data)))
+  expect_true(sdf_nrow(updated_data) == sdf_nrow(sdf_distinct(updated_data)))
 })
 
 test_that("Latest date is as expected", {
-  expect_equal(updated_data$date[1], changes_to)
+  expect_equal( 
+    updated_data %>%
+      sdf_distinct("date") %>%
+      sdf_read_column("date") %>%
+      max(), 
+    changes_to
+  )
 })
 
 test_that("Data has no missing values", {
@@ -115,7 +123,10 @@ test_that("Data has no missing values", {
 
 test_that("There are no missing dates since we started GA4", {
   expect_equal(
-    setdiff(updated_data$date, seq(as.Date(reference_dates$ga4_date), changes_to, by = "day")) |>
+    setdiff(
+      updated_data %>% sdf_distinct("date") %>% sdf_read_column("date"), 
+      seq(as.Date(reference_dates$ga4_date), changes_to, by = "day")
+    ) |>
       length(),
     0
   )
@@ -124,19 +135,17 @@ test_that("There are no missing dates since we started GA4", {
 # COMMAND ----------
 
 # DBTITLE 1,Write to table
-ga4_spark_df <- copy_to(sc, updated_data, overwrite = TRUE)
-
 # Write to temp table while we confirm we're good to overwrite data
-spark_write_table(ga4_spark_df, paste0(table_name, "_temp"), mode = "overwrite")
+spark_write_table(updated_data, paste0(table_name, "_temp"), mode = "overwrite")
 
 temp_table_data <- sparklyr::sdf_sql(sc, paste0("SELECT * FROM ", table_name, "_temp")) %>% collect()
 
 test_that("Temp table data matches updated data", {
-  expect_equal(nrow(temp_table_data), nrow(updated_data))
+  expect_equal(nrow(temp_table_data), sdf_nrow(updated_data))
 })
 
 # Replace the old table with the new one
 dbExecute(sc, paste0("DROP TABLE IF EXISTS ", table_name))
 dbExecute(sc, paste0("ALTER TABLE ", table_name, "_temp RENAME TO ", table_name))
 
-print_changes_summary(temp_table_data, previous_data)
+sdf_print_changes_summary(temp_table_data, previous_data)


### PR DESCRIPTION
## Overview of changes

Like in #16, changing the events notebook to use the spark data frame more, rather than relying on in memory R processing.

## Why are these changes being made?

Recommended optimisation to avoid using copy_to() on a table that has lots of rows, trying to pre-empt it hitting issues as we get more data in.

## Checklist

- [ ] I have ran `styler::style_dir()`
- [ ] I have ran `lintr::lint_dir()`
- [ ] I have updated the documentation
- [ ] I have added or updated automated tests for these changes

## Reviewer instructions

Nothing specific - will just merge once I'm happy so we can see how it runs overnight next week.