### PR TITLE
Add additional duplicate removal case

### DIFF
--- a/data-updates/notebooks/raw_ees_pub_scrape.r
+++ b/data-updates/notebooks/raw_ees_pub_scrape.r
@@ -182,7 +182,8 @@ combined_scrape <- bind_rows(combined_scrape, new_rows) |>
 # DBTITLE 1,Manually adjust for renamed publications
 filtered_scrape <- combined_scrape |>
   filter(!(slug == "participation-in-education-and-training-and-employment" & title == "Participation in education and training and employment") &
-    !(slug == "pupil-absence-in-schools-in-england" & title == "Pupil absence in schools in England: autumn and spring terms"))
+    !(slug == "pupil-absence-in-schools-in-england" & title == "Pupil absence in schools in England: autumn and spring terms") &
+    !(slug == "teacher-and-leader-development-ecf-and-npqs" & title == "Teacher and Leader development: ECF and NPQs")) 
 
 test_that("Each slug has a unique title", {
   duplicate_slugs <- filtered_scrape |>


### PR DESCRIPTION
## Overview of changes

Added an additional clause to clean out an older version of a publication title.

## Why are these changes being made?

[Teacher and leader development: ECF and NPQs](https://explore-education-statistics.service.gov.uk/find-statistics/teacher-and-leader-development-ecf-and-npqs/2023-24) recently renamed to lower case the L in leadership, that flagged as a duplicate title for the slug in our scrap so have added an additional clause to clean out the older version for now.

## Checklist

- [ ] I have ran `styler::style_dir()`
- [ ] I have ran `lintr::lint_dir()`
- [ ] I have updated the documentation
- [ ] I have added or updated automated tests for these changes

## Reviewer instructions

None - I tested and will merge in so the regular job can keep running